### PR TITLE
Fix unsetting feature name flags

### DIFF
--- a/indexer/src/main/scala/importers/geonames/GeonamesParser.scala
+++ b/indexer/src/main/scala/importers/geonames/GeonamesParser.scala
@@ -591,7 +591,7 @@ class GeonamesParser(
                   val newName = DisplayName(dn.lang, dn.name, dn.flags | FeatureNameFlags.PREFERRED.getValue())
                   newName
                 } else {
-                  val newName = DisplayName(dn.lang, dn.name, dn.flags ^ FeatureNameFlags.PREFERRED.getValue())
+                  val newName = DisplayName(dn.lang, dn.name, dn.flags & ~FeatureNameFlags.PREFERRED.getValue())
                   newName
                 }
               } else {


### PR DESCRIPTION
In order to unset some flags there should be `flags AND NOT mask` instead of `flags XOR mask`, right?
