### PR TITLE
De-duplicate bulk responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ id-mapping.txt
 *.shx
 *.prj
 *.zip
+.idea
+latest
+*.iml


### PR DESCRIPTION
Improves bulk query performance by a) de-duplicating features shared for multiple latlongs, and b) requesting each parent id only once.  Also added some gitignore lines for IntelliJ files.
