### PR TITLE
Separate parent features in bulk response

### DIFF
--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkReverseGeocodeRequest.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkReverseGeocodeRequest.java
@@ -339,14 +339,14 @@ public class BulkReverseGeocodeRequest implements TBase<BulkReverseGeocodeReques
         case 1: // LATLNGS
           if (field.type == TType.LIST) {
             {
-              TList _list80 = iprot.readListBegin();
-              this.latlngs = new ArrayList<GeocodePoint>(_list80.size);
-              for (int _i81 = 0; _i81 < _list80.size; ++_i81)
+              TList _list84 = iprot.readListBegin();
+              this.latlngs = new ArrayList<GeocodePoint>(_list84.size);
+              for (int _i85 = 0; _i85 < _list84.size; ++_i85)
               {
-                GeocodePoint _elem82;
-                _elem82 = new GeocodePoint();
-                _elem82.read(iprot);
-                this.latlngs.add(_elem82);
+                GeocodePoint _elem86;
+                _elem86 = new GeocodePoint();
+                _elem86.read(iprot);
+                this.latlngs.add(_elem86);
               }
               iprot.readListEnd();
             }
@@ -382,9 +382,9 @@ public class BulkReverseGeocodeRequest implements TBase<BulkReverseGeocodeReques
         oprot.writeFieldBegin(LATLNGS_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRUCT, this.latlngs.size()));
-          for (GeocodePoint _iter83 : this.latlngs)
+          for (GeocodePoint _iter87 : this.latlngs)
           {
-            _iter83.write(oprot);
+            _iter87.write(oprot);
           }
           oprot.writeListEnd();
         }

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkReverseGeocodeResponse.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkReverseGeocodeResponse.java
@@ -34,11 +34,13 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
   private static final TField DEPRECATED_INTERPRETATION_MAP_FIELD_DESC = new TField("DEPRECATED_interpretationMap", TType.MAP, (short)1);
   private static final TField INTERPRETATIONS_FIELD_DESC = new TField("interpretations", TType.LIST, (short)3);
   private static final TField INTERPRETATION_INDEXES_FIELD_DESC = new TField("interpretationIndexes", TType.LIST, (short)4);
+  private static final TField PARENT_FEATURES_FIELD_DESC = new TField("parentFeatures", TType.LIST, (short)5);
   private static final TField DEBUG_LINES_FIELD_DESC = new TField("debugLines", TType.LIST, (short)2);
 
   public Map<Integer,List<GeocodeInterpretation>> DEPRECATED_interpretationMap;
   public List<GeocodeInterpretation> interpretations;
   public List<List<Integer>> interpretationIndexes;
+  public List<GeocodeFeature> parentFeatures;
   public List<String> debugLines;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
@@ -46,6 +48,7 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
     DEPRECATED_INTERPRETATION_MAP((short)1, "DEPRECATED_interpretationMap"),
     INTERPRETATIONS((short)3, "interpretations"),
     INTERPRETATION_INDEXES((short)4, "interpretationIndexes"),
+    PARENT_FEATURES((short)5, "parentFeatures"),
     DEBUG_LINES((short)2, "debugLines");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -67,6 +70,8 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
           return INTERPRETATIONS;
         case 4: // INTERPRETATION_INDEXES
           return INTERPRETATION_INDEXES;
+        case 5: // PARENT_FEATURES
+          return PARENT_FEATURES;
         case 2: // DEBUG_LINES
           return DEBUG_LINES;
         default:
@@ -125,6 +130,9 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         new ListMetaData(TType.LIST, 
             new ListMetaData(TType.LIST, 
                 new FieldValueMetaData(TType.I32)))));
+    tmpMap.put(_Fields.PARENT_FEATURES, new FieldMetaData("parentFeatures", TFieldRequirementType.OPTIONAL, 
+        new ListMetaData(TType.LIST, 
+            new StructMetaData(TType.STRUCT, GeocodeFeature.class))));
     tmpMap.put(_Fields.DEBUG_LINES, new FieldMetaData("debugLines", TFieldRequirementType.OPTIONAL, 
         new ListMetaData(TType.LIST, 
             new FieldValueMetaData(TType.STRING))));
@@ -186,6 +194,13 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       }
       this.interpretationIndexes = __this__interpretationIndexes;
     }
+    if (other.isSetParentFeatures()) {
+      List<GeocodeFeature> __this__parentFeatures = new ArrayList<GeocodeFeature>();
+      for (GeocodeFeature other_element : other.parentFeatures) {
+        __this__parentFeatures.add(new GeocodeFeature(other_element));
+      }
+      this.parentFeatures = __this__parentFeatures;
+    }
     if (other.isSetDebugLines()) {
       List<String> __this__debugLines = new ArrayList<String>();
       for (String other_element : other.debugLines) {
@@ -204,6 +219,7 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
     this.DEPRECATED_interpretationMap = null;
     this.interpretations = null;
     this.interpretationIndexes = null;
+    this.parentFeatures = null;
     this.debugLines = null;
   }
 
@@ -320,6 +336,45 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
     }
   }
 
+  public int getParentFeaturesSize() {
+    return (this.parentFeatures == null) ? 0 : this.parentFeatures.size();
+  }
+
+  public java.util.Iterator<GeocodeFeature> getParentFeaturesIterator() {
+    return (this.parentFeatures == null) ? null : this.parentFeatures.iterator();
+  }
+
+  public void addToParentFeatures(GeocodeFeature elem) {
+    if (this.parentFeatures == null) {
+      this.parentFeatures = new ArrayList<GeocodeFeature>();
+    }
+    this.parentFeatures.add(elem);
+  }
+
+  public List<GeocodeFeature> getParentFeatures() {
+    return this.parentFeatures;
+  }
+
+  public BulkReverseGeocodeResponse setParentFeatures(List<GeocodeFeature> parentFeatures) {
+    this.parentFeatures = parentFeatures;
+    return this;
+  }
+
+  public void unsetParentFeatures() {
+    this.parentFeatures = null;
+  }
+
+  /** Returns true if field parentFeatures is set (has been asigned a value) and false otherwise */
+  public boolean isSetParentFeatures() {
+    return this.parentFeatures != null;
+  }
+
+  public void setParentFeaturesIsSet(boolean value) {
+    if (!value) {
+      this.parentFeatures = null;
+    }
+  }
+
   public int getDebugLinesSize() {
     return (this.debugLines == null) ? 0 : this.debugLines.size();
   }
@@ -385,6 +440,14 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       }
       break;
 
+    case PARENT_FEATURES:
+      if (value == null) {
+        unsetParentFeatures();
+      } else {
+        setParentFeatures((List<GeocodeFeature>)value);
+      }
+      break;
+
     case DEBUG_LINES:
       if (value == null) {
         unsetDebugLines();
@@ -407,6 +470,9 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
     case INTERPRETATION_INDEXES:
       return getInterpretationIndexes();
 
+    case PARENT_FEATURES:
+      return getParentFeatures();
+
     case DEBUG_LINES:
       return getDebugLines();
 
@@ -427,6 +493,8 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       return isSetInterpretations();
     case INTERPRETATION_INDEXES:
       return isSetInterpretationIndexes();
+    case PARENT_FEATURES:
+      return isSetParentFeatures();
     case DEBUG_LINES:
       return isSetDebugLines();
     }
@@ -470,6 +538,15 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       if (!(this_present_interpretationIndexes && that_present_interpretationIndexes))
         return false;
       if (!this.interpretationIndexes.equals(that.interpretationIndexes))
+        return false;
+    }
+
+    boolean this_present_parentFeatures = true && this.isSetParentFeatures();
+    boolean that_present_parentFeatures = true && that.isSetParentFeatures();
+    if (this_present_parentFeatures || that_present_parentFeatures) {
+      if (!(this_present_parentFeatures && that_present_parentFeatures))
+        return false;
+      if (!this.parentFeatures.equals(that.parentFeatures))
         return false;
     }
 
@@ -528,6 +605,16 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetParentFeatures()).compareTo(typedOther.isSetParentFeatures());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetParentFeatures()) {
+      lastComparison = TBaseHelper.compareTo(this.parentFeatures, typedOther.parentFeatures);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     lastComparison = Boolean.valueOf(isSetDebugLines()).compareTo(typedOther.isSetDebugLines());
     if (lastComparison != 0) {
       return lastComparison;
@@ -558,26 +645,26 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         case 1: // DEPRECATED_INTERPRETATION_MAP
           if (field.type == TType.MAP) {
             {
-              TMap _map84 = iprot.readMapBegin();
-              this.DEPRECATED_interpretationMap = new HashMap<Integer,List<GeocodeInterpretation>>(2*_map84.size);
-              for (int _i85 = 0; _i85 < _map84.size; ++_i85)
+              TMap _map88 = iprot.readMapBegin();
+              this.DEPRECATED_interpretationMap = new HashMap<Integer,List<GeocodeInterpretation>>(2*_map88.size);
+              for (int _i89 = 0; _i89 < _map88.size; ++_i89)
               {
-                int _key86;
-                List<GeocodeInterpretation> _val87;
-                _key86 = iprot.readI32();
+                int _key90;
+                List<GeocodeInterpretation> _val91;
+                _key90 = iprot.readI32();
                 {
-                  TList _list88 = iprot.readListBegin();
-                  _val87 = new ArrayList<GeocodeInterpretation>(_list88.size);
-                  for (int _i89 = 0; _i89 < _list88.size; ++_i89)
+                  TList _list92 = iprot.readListBegin();
+                  _val91 = new ArrayList<GeocodeInterpretation>(_list92.size);
+                  for (int _i93 = 0; _i93 < _list92.size; ++_i93)
                   {
-                    GeocodeInterpretation _elem90;
-                    _elem90 = new GeocodeInterpretation();
-                    _elem90.read(iprot);
-                    _val87.add(_elem90);
+                    GeocodeInterpretation _elem94;
+                    _elem94 = new GeocodeInterpretation();
+                    _elem94.read(iprot);
+                    _val91.add(_elem94);
                   }
                   iprot.readListEnd();
                 }
-                this.DEPRECATED_interpretationMap.put(_key86, _val87);
+                this.DEPRECATED_interpretationMap.put(_key90, _val91);
               }
               iprot.readMapEnd();
             }
@@ -588,14 +675,14 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         case 3: // INTERPRETATIONS
           if (field.type == TType.LIST) {
             {
-              TList _list91 = iprot.readListBegin();
-              this.interpretations = new ArrayList<GeocodeInterpretation>(_list91.size);
-              for (int _i92 = 0; _i92 < _list91.size; ++_i92)
+              TList _list95 = iprot.readListBegin();
+              this.interpretations = new ArrayList<GeocodeInterpretation>(_list95.size);
+              for (int _i96 = 0; _i96 < _list95.size; ++_i96)
               {
-                GeocodeInterpretation _elem93;
-                _elem93 = new GeocodeInterpretation();
-                _elem93.read(iprot);
-                this.interpretations.add(_elem93);
+                GeocodeInterpretation _elem97;
+                _elem97 = new GeocodeInterpretation();
+                _elem97.read(iprot);
+                this.interpretations.add(_elem97);
               }
               iprot.readListEnd();
             }
@@ -606,23 +693,41 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         case 4: // INTERPRETATION_INDEXES
           if (field.type == TType.LIST) {
             {
-              TList _list94 = iprot.readListBegin();
-              this.interpretationIndexes = new ArrayList<List<Integer>>(_list94.size);
-              for (int _i95 = 0; _i95 < _list94.size; ++_i95)
+              TList _list98 = iprot.readListBegin();
+              this.interpretationIndexes = new ArrayList<List<Integer>>(_list98.size);
+              for (int _i99 = 0; _i99 < _list98.size; ++_i99)
               {
-                List<Integer> _elem96;
+                List<Integer> _elem100;
                 {
-                  TList _list97 = iprot.readListBegin();
-                  _elem96 = new ArrayList<Integer>(_list97.size);
-                  for (int _i98 = 0; _i98 < _list97.size; ++_i98)
+                  TList _list101 = iprot.readListBegin();
+                  _elem100 = new ArrayList<Integer>(_list101.size);
+                  for (int _i102 = 0; _i102 < _list101.size; ++_i102)
                   {
-                    int _elem99;
-                    _elem99 = iprot.readI32();
-                    _elem96.add(_elem99);
+                    int _elem103;
+                    _elem103 = iprot.readI32();
+                    _elem100.add(_elem103);
                   }
                   iprot.readListEnd();
                 }
-                this.interpretationIndexes.add(_elem96);
+                this.interpretationIndexes.add(_elem100);
+              }
+              iprot.readListEnd();
+            }
+          } else { 
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 5: // PARENT_FEATURES
+          if (field.type == TType.LIST) {
+            {
+              TList _list104 = iprot.readListBegin();
+              this.parentFeatures = new ArrayList<GeocodeFeature>(_list104.size);
+              for (int _i105 = 0; _i105 < _list104.size; ++_i105)
+              {
+                GeocodeFeature _elem106;
+                _elem106 = new GeocodeFeature();
+                _elem106.read(iprot);
+                this.parentFeatures.add(_elem106);
               }
               iprot.readListEnd();
             }
@@ -633,13 +738,13 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         case 2: // DEBUG_LINES
           if (field.type == TType.LIST) {
             {
-              TList _list100 = iprot.readListBegin();
-              this.debugLines = new ArrayList<String>(_list100.size);
-              for (int _i101 = 0; _i101 < _list100.size; ++_i101)
+              TList _list107 = iprot.readListBegin();
+              this.debugLines = new ArrayList<String>(_list107.size);
+              for (int _i108 = 0; _i108 < _list107.size; ++_i108)
               {
-                String _elem102;
-                _elem102 = iprot.readString();
-                this.debugLines.add(_elem102);
+                String _elem109;
+                _elem109 = iprot.readString();
+                this.debugLines.add(_elem109);
               }
               iprot.readListEnd();
             }
@@ -666,14 +771,14 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       oprot.writeFieldBegin(DEPRECATED_INTERPRETATION_MAP_FIELD_DESC);
       {
         oprot.writeMapBegin(new TMap(TType.I32, TType.LIST, this.DEPRECATED_interpretationMap.size()));
-        for (Map.Entry<Integer, List<GeocodeInterpretation>> _iter103 : this.DEPRECATED_interpretationMap.entrySet())
+        for (Map.Entry<Integer, List<GeocodeInterpretation>> _iter110 : this.DEPRECATED_interpretationMap.entrySet())
         {
-          oprot.writeI32(_iter103.getKey());
+          oprot.writeI32(_iter110.getKey());
           {
-            oprot.writeListBegin(new TList(TType.STRUCT, _iter103.getValue().size()));
-            for (GeocodeInterpretation _iter104 : _iter103.getValue())
+            oprot.writeListBegin(new TList(TType.STRUCT, _iter110.getValue().size()));
+            for (GeocodeInterpretation _iter111 : _iter110.getValue())
             {
-              _iter104.write(oprot);
+              _iter111.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -687,9 +792,9 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         oprot.writeFieldBegin(DEBUG_LINES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.debugLines.size()));
-          for (String _iter105 : this.debugLines)
+          for (String _iter112 : this.debugLines)
           {
-            oprot.writeString(_iter105);
+            oprot.writeString(_iter112);
           }
           oprot.writeListEnd();
         }
@@ -700,9 +805,9 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       oprot.writeFieldBegin(INTERPRETATIONS_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.STRUCT, this.interpretations.size()));
-        for (GeocodeInterpretation _iter106 : this.interpretations)
+        for (GeocodeInterpretation _iter113 : this.interpretations)
         {
-          _iter106.write(oprot);
+          _iter113.write(oprot);
         }
         oprot.writeListEnd();
       }
@@ -712,13 +817,13 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       oprot.writeFieldBegin(INTERPRETATION_INDEXES_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.LIST, this.interpretationIndexes.size()));
-        for (List<Integer> _iter107 : this.interpretationIndexes)
+        for (List<Integer> _iter114 : this.interpretationIndexes)
         {
           {
-            oprot.writeListBegin(new TList(TType.I32, _iter107.size()));
-            for (int _iter108 : _iter107)
+            oprot.writeListBegin(new TList(TType.I32, _iter114.size()));
+            for (int _iter115 : _iter114)
             {
-              oprot.writeI32(_iter108);
+              oprot.writeI32(_iter115);
             }
             oprot.writeListEnd();
           }
@@ -726,6 +831,20 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
         oprot.writeListEnd();
       }
       oprot.writeFieldEnd();
+    }
+    if (this.parentFeatures != null) {
+      if (isSetParentFeatures()) {
+        oprot.writeFieldBegin(PARENT_FEATURES_FIELD_DESC);
+        {
+          oprot.writeListBegin(new TList(TType.STRUCT, this.parentFeatures.size()));
+          for (GeocodeFeature _iter116 : this.parentFeatures)
+          {
+            _iter116.write(oprot);
+          }
+          oprot.writeListEnd();
+        }
+        oprot.writeFieldEnd();
+      }
     }
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -759,6 +878,16 @@ public class BulkReverseGeocodeResponse implements TBase<BulkReverseGeocodeRespo
       sb.append(this.interpretationIndexes);
     }
     first = false;
+    if (isSetParentFeatures()) {
+      if (!first) sb.append(", ");
+      sb.append("parentFeatures:");
+      if (this.parentFeatures == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.parentFeatures);
+      }
+      first = false;
+    }
     if (isSetDebugLines()) {
       if (!first) sb.append(", ");
       sb.append("debugLines:");

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkSlugLookupRequest.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkSlugLookupRequest.java
@@ -339,13 +339,13 @@ public class BulkSlugLookupRequest implements TBase<BulkSlugLookupRequest, BulkS
         case 1: // SLUGS
           if (field.type == TType.LIST) {
             {
-              TList _list109 = iprot.readListBegin();
-              this.slugs = new ArrayList<String>(_list109.size);
-              for (int _i110 = 0; _i110 < _list109.size; ++_i110)
+              TList _list117 = iprot.readListBegin();
+              this.slugs = new ArrayList<String>(_list117.size);
+              for (int _i118 = 0; _i118 < _list117.size; ++_i118)
               {
-                String _elem111;
-                _elem111 = iprot.readString();
-                this.slugs.add(_elem111);
+                String _elem119;
+                _elem119 = iprot.readString();
+                this.slugs.add(_elem119);
               }
               iprot.readListEnd();
             }
@@ -381,9 +381,9 @@ public class BulkSlugLookupRequest implements TBase<BulkSlugLookupRequest, BulkS
         oprot.writeFieldBegin(SLUGS_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.slugs.size()));
-          for (String _iter112 : this.slugs)
+          for (String _iter120 : this.slugs)
           {
-            oprot.writeString(_iter112);
+            oprot.writeString(_iter120);
           }
           oprot.writeListEnd();
         }

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkSlugLookupResponse.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/BulkSlugLookupResponse.java
@@ -33,16 +33,19 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
 
   private static final TField INTERPRETATIONS_FIELD_DESC = new TField("interpretations", TType.LIST, (short)1);
   private static final TField INTERPRETATION_INDEXES_FIELD_DESC = new TField("interpretationIndexes", TType.LIST, (short)2);
+  private static final TField PARENT_FEATURES_FIELD_DESC = new TField("parentFeatures", TType.LIST, (short)4);
   private static final TField DEBUG_LINES_FIELD_DESC = new TField("debugLines", TType.LIST, (short)3);
 
   public List<GeocodeInterpretation> interpretations;
   public List<List<Integer>> interpretationIndexes;
+  public List<GeocodeFeature> parentFeatures;
   public List<String> debugLines;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements TFieldIdEnum {
     INTERPRETATIONS((short)1, "interpretations"),
     INTERPRETATION_INDEXES((short)2, "interpretationIndexes"),
+    PARENT_FEATURES((short)4, "parentFeatures"),
     DEBUG_LINES((short)3, "debugLines");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -62,6 +65,8 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
           return INTERPRETATIONS;
         case 2: // INTERPRETATION_INDEXES
           return INTERPRETATION_INDEXES;
+        case 4: // PARENT_FEATURES
+          return PARENT_FEATURES;
         case 3: // DEBUG_LINES
           return DEBUG_LINES;
         default:
@@ -115,6 +120,9 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         new ListMetaData(TType.LIST, 
             new ListMetaData(TType.LIST, 
                 new FieldValueMetaData(TType.I32)))));
+    tmpMap.put(_Fields.PARENT_FEATURES, new FieldMetaData("parentFeatures", TFieldRequirementType.OPTIONAL, 
+        new ListMetaData(TType.LIST, 
+            new StructMetaData(TType.STRUCT, GeocodeFeature.class))));
     tmpMap.put(_Fields.DEBUG_LINES, new FieldMetaData("debugLines", TFieldRequirementType.OPTIONAL, 
         new ListMetaData(TType.LIST, 
             new FieldValueMetaData(TType.STRING))));
@@ -156,6 +164,13 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       }
       this.interpretationIndexes = __this__interpretationIndexes;
     }
+    if (other.isSetParentFeatures()) {
+      List<GeocodeFeature> __this__parentFeatures = new ArrayList<GeocodeFeature>();
+      for (GeocodeFeature other_element : other.parentFeatures) {
+        __this__parentFeatures.add(new GeocodeFeature(other_element));
+      }
+      this.parentFeatures = __this__parentFeatures;
+    }
     if (other.isSetDebugLines()) {
       List<String> __this__debugLines = new ArrayList<String>();
       for (String other_element : other.debugLines) {
@@ -173,6 +188,7 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
   public void clear() {
     this.interpretations = null;
     this.interpretationIndexes = null;
+    this.parentFeatures = null;
     this.debugLines = null;
   }
 
@@ -254,6 +270,45 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
     }
   }
 
+  public int getParentFeaturesSize() {
+    return (this.parentFeatures == null) ? 0 : this.parentFeatures.size();
+  }
+
+  public java.util.Iterator<GeocodeFeature> getParentFeaturesIterator() {
+    return (this.parentFeatures == null) ? null : this.parentFeatures.iterator();
+  }
+
+  public void addToParentFeatures(GeocodeFeature elem) {
+    if (this.parentFeatures == null) {
+      this.parentFeatures = new ArrayList<GeocodeFeature>();
+    }
+    this.parentFeatures.add(elem);
+  }
+
+  public List<GeocodeFeature> getParentFeatures() {
+    return this.parentFeatures;
+  }
+
+  public BulkSlugLookupResponse setParentFeatures(List<GeocodeFeature> parentFeatures) {
+    this.parentFeatures = parentFeatures;
+    return this;
+  }
+
+  public void unsetParentFeatures() {
+    this.parentFeatures = null;
+  }
+
+  /** Returns true if field parentFeatures is set (has been asigned a value) and false otherwise */
+  public boolean isSetParentFeatures() {
+    return this.parentFeatures != null;
+  }
+
+  public void setParentFeaturesIsSet(boolean value) {
+    if (!value) {
+      this.parentFeatures = null;
+    }
+  }
+
   public int getDebugLinesSize() {
     return (this.debugLines == null) ? 0 : this.debugLines.size();
   }
@@ -311,6 +366,14 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       }
       break;
 
+    case PARENT_FEATURES:
+      if (value == null) {
+        unsetParentFeatures();
+      } else {
+        setParentFeatures((List<GeocodeFeature>)value);
+      }
+      break;
+
     case DEBUG_LINES:
       if (value == null) {
         unsetDebugLines();
@@ -330,6 +393,9 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
     case INTERPRETATION_INDEXES:
       return getInterpretationIndexes();
 
+    case PARENT_FEATURES:
+      return getParentFeatures();
+
     case DEBUG_LINES:
       return getDebugLines();
 
@@ -348,6 +414,8 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       return isSetInterpretations();
     case INTERPRETATION_INDEXES:
       return isSetInterpretationIndexes();
+    case PARENT_FEATURES:
+      return isSetParentFeatures();
     case DEBUG_LINES:
       return isSetDebugLines();
     }
@@ -382,6 +450,15 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       if (!(this_present_interpretationIndexes && that_present_interpretationIndexes))
         return false;
       if (!this.interpretationIndexes.equals(that.interpretationIndexes))
+        return false;
+    }
+
+    boolean this_present_parentFeatures = true && this.isSetParentFeatures();
+    boolean that_present_parentFeatures = true && that.isSetParentFeatures();
+    if (this_present_parentFeatures || that_present_parentFeatures) {
+      if (!(this_present_parentFeatures && that_present_parentFeatures))
+        return false;
+      if (!this.parentFeatures.equals(that.parentFeatures))
         return false;
     }
 
@@ -430,6 +507,16 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetParentFeatures()).compareTo(typedOther.isSetParentFeatures());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetParentFeatures()) {
+      lastComparison = TBaseHelper.compareTo(this.parentFeatures, typedOther.parentFeatures);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     lastComparison = Boolean.valueOf(isSetDebugLines()).compareTo(typedOther.isSetDebugLines());
     if (lastComparison != 0) {
       return lastComparison;
@@ -460,14 +547,14 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         case 1: // INTERPRETATIONS
           if (field.type == TType.LIST) {
             {
-              TList _list113 = iprot.readListBegin();
-              this.interpretations = new ArrayList<GeocodeInterpretation>(_list113.size);
-              for (int _i114 = 0; _i114 < _list113.size; ++_i114)
+              TList _list121 = iprot.readListBegin();
+              this.interpretations = new ArrayList<GeocodeInterpretation>(_list121.size);
+              for (int _i122 = 0; _i122 < _list121.size; ++_i122)
               {
-                GeocodeInterpretation _elem115;
-                _elem115 = new GeocodeInterpretation();
-                _elem115.read(iprot);
-                this.interpretations.add(_elem115);
+                GeocodeInterpretation _elem123;
+                _elem123 = new GeocodeInterpretation();
+                _elem123.read(iprot);
+                this.interpretations.add(_elem123);
               }
               iprot.readListEnd();
             }
@@ -478,23 +565,41 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         case 2: // INTERPRETATION_INDEXES
           if (field.type == TType.LIST) {
             {
-              TList _list116 = iprot.readListBegin();
-              this.interpretationIndexes = new ArrayList<List<Integer>>(_list116.size);
-              for (int _i117 = 0; _i117 < _list116.size; ++_i117)
+              TList _list124 = iprot.readListBegin();
+              this.interpretationIndexes = new ArrayList<List<Integer>>(_list124.size);
+              for (int _i125 = 0; _i125 < _list124.size; ++_i125)
               {
-                List<Integer> _elem118;
+                List<Integer> _elem126;
                 {
-                  TList _list119 = iprot.readListBegin();
-                  _elem118 = new ArrayList<Integer>(_list119.size);
-                  for (int _i120 = 0; _i120 < _list119.size; ++_i120)
+                  TList _list127 = iprot.readListBegin();
+                  _elem126 = new ArrayList<Integer>(_list127.size);
+                  for (int _i128 = 0; _i128 < _list127.size; ++_i128)
                   {
-                    int _elem121;
-                    _elem121 = iprot.readI32();
-                    _elem118.add(_elem121);
+                    int _elem129;
+                    _elem129 = iprot.readI32();
+                    _elem126.add(_elem129);
                   }
                   iprot.readListEnd();
                 }
-                this.interpretationIndexes.add(_elem118);
+                this.interpretationIndexes.add(_elem126);
+              }
+              iprot.readListEnd();
+            }
+          } else { 
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 4: // PARENT_FEATURES
+          if (field.type == TType.LIST) {
+            {
+              TList _list130 = iprot.readListBegin();
+              this.parentFeatures = new ArrayList<GeocodeFeature>(_list130.size);
+              for (int _i131 = 0; _i131 < _list130.size; ++_i131)
+              {
+                GeocodeFeature _elem132;
+                _elem132 = new GeocodeFeature();
+                _elem132.read(iprot);
+                this.parentFeatures.add(_elem132);
               }
               iprot.readListEnd();
             }
@@ -505,13 +610,13 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         case 3: // DEBUG_LINES
           if (field.type == TType.LIST) {
             {
-              TList _list122 = iprot.readListBegin();
-              this.debugLines = new ArrayList<String>(_list122.size);
-              for (int _i123 = 0; _i123 < _list122.size; ++_i123)
+              TList _list133 = iprot.readListBegin();
+              this.debugLines = new ArrayList<String>(_list133.size);
+              for (int _i134 = 0; _i134 < _list133.size; ++_i134)
               {
-                String _elem124;
-                _elem124 = iprot.readString();
-                this.debugLines.add(_elem124);
+                String _elem135;
+                _elem135 = iprot.readString();
+                this.debugLines.add(_elem135);
               }
               iprot.readListEnd();
             }
@@ -538,9 +643,9 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       oprot.writeFieldBegin(INTERPRETATIONS_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.STRUCT, this.interpretations.size()));
-        for (GeocodeInterpretation _iter125 : this.interpretations)
+        for (GeocodeInterpretation _iter136 : this.interpretations)
         {
-          _iter125.write(oprot);
+          _iter136.write(oprot);
         }
         oprot.writeListEnd();
       }
@@ -550,13 +655,13 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       oprot.writeFieldBegin(INTERPRETATION_INDEXES_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.LIST, this.interpretationIndexes.size()));
-        for (List<Integer> _iter126 : this.interpretationIndexes)
+        for (List<Integer> _iter137 : this.interpretationIndexes)
         {
           {
-            oprot.writeListBegin(new TList(TType.I32, _iter126.size()));
-            for (int _iter127 : _iter126)
+            oprot.writeListBegin(new TList(TType.I32, _iter137.size()));
+            for (int _iter138 : _iter137)
             {
-              oprot.writeI32(_iter127);
+              oprot.writeI32(_iter138);
             }
             oprot.writeListEnd();
           }
@@ -570,9 +675,23 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
         oprot.writeFieldBegin(DEBUG_LINES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.debugLines.size()));
-          for (String _iter128 : this.debugLines)
+          for (String _iter139 : this.debugLines)
           {
-            oprot.writeString(_iter128);
+            oprot.writeString(_iter139);
+          }
+          oprot.writeListEnd();
+        }
+        oprot.writeFieldEnd();
+      }
+    }
+    if (this.parentFeatures != null) {
+      if (isSetParentFeatures()) {
+        oprot.writeFieldBegin(PARENT_FEATURES_FIELD_DESC);
+        {
+          oprot.writeListBegin(new TList(TType.STRUCT, this.parentFeatures.size()));
+          for (GeocodeFeature _iter140 : this.parentFeatures)
+          {
+            _iter140.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -603,6 +722,16 @@ public class BulkSlugLookupResponse implements TBase<BulkSlugLookupResponse, Bul
       sb.append(this.interpretationIndexes);
     }
     first = false;
+    if (isSetParentFeatures()) {
+      if (!first) sb.append(", ");
+      sb.append("parentFeatures:");
+      if (this.parentFeatures == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.parentFeatures);
+      }
+      first = false;
+    }
     if (isSetDebugLines()) {
       if (!first) sb.append(", ");
       sb.append("debugLines:");

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/CommonGeocodeRequestParams.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/CommonGeocodeRequestParams.java
@@ -960,13 +960,13 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         case 2: // WOE_HINT
           if (field.type == TType.LIST) {
             {
-              TList _list64 = iprot.readListBegin();
-              this.woeHint = new ArrayList<YahooWoeType>(_list64.size);
-              for (int _i65 = 0; _i65 < _list64.size; ++_i65)
+              TList _list68 = iprot.readListBegin();
+              this.woeHint = new ArrayList<YahooWoeType>(_list68.size);
+              for (int _i69 = 0; _i69 < _list68.size; ++_i69)
               {
-                YahooWoeType _elem66;
-                _elem66 = YahooWoeType.findByValue(iprot.readI32());
-                this.woeHint.add(_elem66);
+                YahooWoeType _elem70;
+                _elem70 = YahooWoeType.findByValue(iprot.readI32());
+                this.woeHint.add(_elem70);
               }
               iprot.readListEnd();
             }
@@ -977,13 +977,13 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         case 3: // WOE_RESTRICT
           if (field.type == TType.LIST) {
             {
-              TList _list67 = iprot.readListBegin();
-              this.woeRestrict = new ArrayList<YahooWoeType>(_list67.size);
-              for (int _i68 = 0; _i68 < _list67.size; ++_i68)
+              TList _list71 = iprot.readListBegin();
+              this.woeRestrict = new ArrayList<YahooWoeType>(_list71.size);
+              for (int _i72 = 0; _i72 < _list71.size; ++_i72)
               {
-                YahooWoeType _elem69;
-                _elem69 = YahooWoeType.findByValue(iprot.readI32());
-                this.woeRestrict.add(_elem69);
+                YahooWoeType _elem73;
+                _elem73 = YahooWoeType.findByValue(iprot.readI32());
+                this.woeRestrict.add(_elem73);
               }
               iprot.readListEnd();
             }
@@ -1008,13 +1008,13 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         case 6: // RESPONSE_INCLUDES
           if (field.type == TType.LIST) {
             {
-              TList _list70 = iprot.readListBegin();
-              this.responseIncludes = new ArrayList<ResponseIncludes>(_list70.size);
-              for (int _i71 = 0; _i71 < _list70.size; ++_i71)
+              TList _list74 = iprot.readListBegin();
+              this.responseIncludes = new ArrayList<ResponseIncludes>(_list74.size);
+              for (int _i75 = 0; _i75 < _list74.size; ++_i75)
               {
-                ResponseIncludes _elem72;
-                _elem72 = ResponseIncludes.findByValue(iprot.readI32());
-                this.responseIncludes.add(_elem72);
+                ResponseIncludes _elem76;
+                _elem76 = ResponseIncludes.findByValue(iprot.readI32());
+                this.responseIncludes.add(_elem76);
               }
               iprot.readListEnd();
             }
@@ -1025,13 +1025,13 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         case 7: // ALLOWED_SOURCES
           if (field.type == TType.LIST) {
             {
-              TList _list73 = iprot.readListBegin();
-              this.allowedSources = new ArrayList<String>(_list73.size);
-              for (int _i74 = 0; _i74 < _list73.size; ++_i74)
+              TList _list77 = iprot.readListBegin();
+              this.allowedSources = new ArrayList<String>(_list77.size);
+              for (int _i78 = 0; _i78 < _list77.size; ++_i78)
               {
-                String _elem75;
-                _elem75 = iprot.readString();
-                this.allowedSources.add(_elem75);
+                String _elem79;
+                _elem79 = iprot.readString();
+                this.allowedSources.add(_elem79);
               }
               iprot.readListEnd();
             }
@@ -1088,9 +1088,9 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         oprot.writeFieldBegin(WOE_HINT_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.woeHint.size()));
-          for (YahooWoeType _iter76 : this.woeHint)
+          for (YahooWoeType _iter80 : this.woeHint)
           {
-            oprot.writeI32(_iter76.getValue());
+            oprot.writeI32(_iter80.getValue());
           }
           oprot.writeListEnd();
         }
@@ -1102,9 +1102,9 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         oprot.writeFieldBegin(WOE_RESTRICT_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.woeRestrict.size()));
-          for (YahooWoeType _iter77 : this.woeRestrict)
+          for (YahooWoeType _iter81 : this.woeRestrict)
           {
-            oprot.writeI32(_iter77.getValue());
+            oprot.writeI32(_iter81.getValue());
           }
           oprot.writeListEnd();
         }
@@ -1130,9 +1130,9 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         oprot.writeFieldBegin(RESPONSE_INCLUDES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.responseIncludes.size()));
-          for (ResponseIncludes _iter78 : this.responseIncludes)
+          for (ResponseIncludes _iter82 : this.responseIncludes)
           {
-            oprot.writeI32(_iter78.getValue());
+            oprot.writeI32(_iter82.getValue());
           }
           oprot.writeListEnd();
         }
@@ -1144,9 +1144,9 @@ public class CommonGeocodeRequestParams implements TBase<CommonGeocodeRequestPar
         oprot.writeFieldBegin(ALLOWED_SOURCES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.allowedSources.size()));
-          for (String _iter79 : this.allowedSources)
+          for (String _iter83 : this.allowedSources)
           {
-            oprot.writeString(_iter79);
+            oprot.writeString(_iter83);
           }
           oprot.writeListEnd();
         }

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeInterpretation.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeInterpretation.java
@@ -38,6 +38,7 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
   private static final TField SCORING_FEATURES__DEPRECATED_FIELD_DESC = new TField("scoringFeatures_DEPRECATED", TType.STRUCT, (short)5);
   private static final TField SCORES_FIELD_DESC = new TField("scores", TType.STRUCT, (short)6);
   private static final TField DEBUG_INFO_FIELD_DESC = new TField("debugInfo", TType.STRUCT, (short)7);
+  private static final TField PARENT_LONG_IDS_FIELD_DESC = new TField("parentLongIds", TType.LIST, (short)8);
 
   public String what;
   public String where;
@@ -46,6 +47,7 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
   public ScoringFeatures scoringFeatures_DEPRECATED;
   public InterpretationScoringFeatures scores;
   public InterpretationDebugInfo debugInfo;
+  public List<Long> parentLongIds;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements TFieldIdEnum {
@@ -55,7 +57,8 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
     PARENTS((short)4, "parents"),
     SCORING_FEATURES__DEPRECATED((short)5, "scoringFeatures_DEPRECATED"),
     SCORES((short)6, "scores"),
-    DEBUG_INFO((short)7, "debugInfo");
+    DEBUG_INFO((short)7, "debugInfo"),
+    PARENT_LONG_IDS((short)8, "parentLongIds");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -84,6 +87,8 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
           return SCORES;
         case 7: // DEBUG_INFO
           return DEBUG_INFO;
+        case 8: // PARENT_LONG_IDS
+          return PARENT_LONG_IDS;
         default:
           return null;
       }
@@ -143,6 +148,9 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
         new StructMetaData(TType.STRUCT, InterpretationScoringFeatures.class)));
     tmpMap.put(_Fields.DEBUG_INFO, new FieldMetaData("debugInfo", TFieldRequirementType.OPTIONAL, 
         new StructMetaData(TType.STRUCT, InterpretationDebugInfo.class)));
+    tmpMap.put(_Fields.PARENT_LONG_IDS, new FieldMetaData("parentLongIds", TFieldRequirementType.OPTIONAL, 
+        new ListMetaData(TType.LIST, 
+            new FieldValueMetaData(TType.I64))));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     FieldMetaData.addStructMetaDataMap(GeocodeInterpretation.class, metaDataMap);
   }
@@ -190,6 +198,13 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
     if (other.isSetDebugInfo()) {
       this.debugInfo = new InterpretationDebugInfo(other.debugInfo);
     }
+    if (other.isSetParentLongIds()) {
+      List<Long> __this__parentLongIds = new ArrayList<Long>();
+      for (Long other_element : other.parentLongIds) {
+        __this__parentLongIds.add(other_element);
+      }
+      this.parentLongIds = __this__parentLongIds;
+    }
   }
 
   public GeocodeInterpretation deepCopy() {
@@ -205,6 +220,7 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
     this.scoringFeatures_DEPRECATED = null;
     this.scores = null;
     this.debugInfo = null;
+    this.parentLongIds = null;
   }
 
   public String getWhat() {
@@ -390,6 +406,45 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
     }
   }
 
+  public int getParentLongIdsSize() {
+    return (this.parentLongIds == null) ? 0 : this.parentLongIds.size();
+  }
+
+  public java.util.Iterator<Long> getParentLongIdsIterator() {
+    return (this.parentLongIds == null) ? null : this.parentLongIds.iterator();
+  }
+
+  public void addToParentLongIds(long elem) {
+    if (this.parentLongIds == null) {
+      this.parentLongIds = new ArrayList<Long>();
+    }
+    this.parentLongIds.add(elem);
+  }
+
+  public List<Long> getParentLongIds() {
+    return this.parentLongIds;
+  }
+
+  public GeocodeInterpretation setParentLongIds(List<Long> parentLongIds) {
+    this.parentLongIds = parentLongIds;
+    return this;
+  }
+
+  public void unsetParentLongIds() {
+    this.parentLongIds = null;
+  }
+
+  /** Returns true if field parentLongIds is set (has been asigned a value) and false otherwise */
+  public boolean isSetParentLongIds() {
+    return this.parentLongIds != null;
+  }
+
+  public void setParentLongIdsIsSet(boolean value) {
+    if (!value) {
+      this.parentLongIds = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case WHAT:
@@ -448,6 +503,14 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
       }
       break;
 
+    case PARENT_LONG_IDS:
+      if (value == null) {
+        unsetParentLongIds();
+      } else {
+        setParentLongIds((List<Long>)value);
+      }
+      break;
+
     }
   }
 
@@ -474,6 +537,9 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
     case DEBUG_INFO:
       return getDebugInfo();
 
+    case PARENT_LONG_IDS:
+      return getParentLongIds();
+
     }
     throw new IllegalStateException();
   }
@@ -499,6 +565,8 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
       return isSetScores();
     case DEBUG_INFO:
       return isSetDebugInfo();
+    case PARENT_LONG_IDS:
+      return isSetParentLongIds();
     }
     throw new IllegalStateException();
   }
@@ -576,6 +644,15 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
       if (!(this_present_debugInfo && that_present_debugInfo))
         return false;
       if (!this.debugInfo.equals(that.debugInfo))
+        return false;
+    }
+
+    boolean this_present_parentLongIds = true && this.isSetParentLongIds();
+    boolean that_present_parentLongIds = true && that.isSetParentLongIds();
+    if (this_present_parentLongIds || that_present_parentLongIds) {
+      if (!(this_present_parentLongIds && that_present_parentLongIds))
+        return false;
+      if (!this.parentLongIds.equals(that.parentLongIds))
         return false;
     }
 
@@ -665,6 +742,16 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(isSetParentLongIds()).compareTo(typedOther.isSetParentLongIds());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetParentLongIds()) {
+      lastComparison = TBaseHelper.compareTo(this.parentLongIds, typedOther.parentLongIds);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -746,6 +833,23 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
             TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case 8: // PARENT_LONG_IDS
+          if (field.type == TType.LIST) {
+            {
+              TList _list39 = iprot.readListBegin();
+              this.parentLongIds = new ArrayList<Long>(_list39.size);
+              for (int _i40 = 0; _i40 < _list39.size; ++_i40)
+              {
+                long _elem41;
+                _elem41 = iprot.readI64();
+                this.parentLongIds.add(_elem41);
+              }
+              iprot.readListEnd();
+            }
+          } else { 
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           TProtocolUtil.skip(iprot, field.type);
       }
@@ -781,9 +885,9 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
         oprot.writeFieldBegin(PARENTS_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRUCT, this.parents.size()));
-          for (GeocodeFeature _iter39 : this.parents)
+          for (GeocodeFeature _iter42 : this.parents)
           {
-            _iter39.write(oprot);
+            _iter42.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -808,6 +912,20 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
       if (isSetDebugInfo()) {
         oprot.writeFieldBegin(DEBUG_INFO_FIELD_DESC);
         this.debugInfo.write(oprot);
+        oprot.writeFieldEnd();
+      }
+    }
+    if (this.parentLongIds != null) {
+      if (isSetParentLongIds()) {
+        oprot.writeFieldBegin(PARENT_LONG_IDS_FIELD_DESC);
+        {
+          oprot.writeListBegin(new TList(TType.I64, this.parentLongIds.size()));
+          for (long _iter43 : this.parentLongIds)
+          {
+            oprot.writeI64(_iter43);
+          }
+          oprot.writeListEnd();
+        }
         oprot.writeFieldEnd();
       }
     }
@@ -880,6 +998,16 @@ public class GeocodeInterpretation implements TBase<GeocodeInterpretation, Geoco
         sb.append("null");
       } else {
         sb.append(this.debugInfo);
+      }
+      first = false;
+    }
+    if (isSetParentLongIds()) {
+      if (!first) sb.append(", ");
+      sb.append("parentLongIds:");
+      if (this.parentLongIds == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.parentLongIds);
       }
       first = false;
     }

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeRequest.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeRequest.java
@@ -1411,13 +1411,13 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         case 8: // WOE_HINT
           if (field.type == TType.LIST) {
             {
-              TList _list48 = iprot.readListBegin();
-              this.woeHint = new ArrayList<YahooWoeType>(_list48.size);
-              for (int _i49 = 0; _i49 < _list48.size; ++_i49)
+              TList _list52 = iprot.readListBegin();
+              this.woeHint = new ArrayList<YahooWoeType>(_list52.size);
+              for (int _i53 = 0; _i53 < _list52.size; ++_i53)
               {
-                YahooWoeType _elem50;
-                _elem50 = YahooWoeType.findByValue(iprot.readI32());
-                this.woeHint.add(_elem50);
+                YahooWoeType _elem54;
+                _elem54 = YahooWoeType.findByValue(iprot.readI32());
+                this.woeHint.add(_elem54);
               }
               iprot.readListEnd();
             }
@@ -1428,13 +1428,13 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         case 9: // WOE_RESTRICT
           if (field.type == TType.LIST) {
             {
-              TList _list51 = iprot.readListBegin();
-              this.woeRestrict = new ArrayList<YahooWoeType>(_list51.size);
-              for (int _i52 = 0; _i52 < _list51.size; ++_i52)
+              TList _list55 = iprot.readListBegin();
+              this.woeRestrict = new ArrayList<YahooWoeType>(_list55.size);
+              for (int _i56 = 0; _i56 < _list55.size; ++_i56)
               {
-                YahooWoeType _elem53;
-                _elem53 = YahooWoeType.findByValue(iprot.readI32());
-                this.woeRestrict.add(_elem53);
+                YahooWoeType _elem57;
+                _elem57 = YahooWoeType.findByValue(iprot.readI32());
+                this.woeRestrict.add(_elem57);
               }
               iprot.readListEnd();
             }
@@ -1484,13 +1484,13 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         case 17: // ALLOWED_SOURCES
           if (field.type == TType.LIST) {
             {
-              TList _list54 = iprot.readListBegin();
-              this.allowedSources = new ArrayList<String>(_list54.size);
-              for (int _i55 = 0; _i55 < _list54.size; ++_i55)
+              TList _list58 = iprot.readListBegin();
+              this.allowedSources = new ArrayList<String>(_list58.size);
+              for (int _i59 = 0; _i59 < _list58.size; ++_i59)
               {
-                String _elem56;
-                _elem56 = iprot.readString();
-                this.allowedSources.add(_elem56);
+                String _elem60;
+                _elem60 = iprot.readString();
+                this.allowedSources.add(_elem60);
               }
               iprot.readListEnd();
             }
@@ -1501,13 +1501,13 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         case 18: // RESPONSE_INCLUDES
           if (field.type == TType.LIST) {
             {
-              TList _list57 = iprot.readListBegin();
-              this.responseIncludes = new ArrayList<ResponseIncludes>(_list57.size);
-              for (int _i58 = 0; _i58 < _list57.size; ++_i58)
+              TList _list61 = iprot.readListBegin();
+              this.responseIncludes = new ArrayList<ResponseIncludes>(_list61.size);
+              for (int _i62 = 0; _i62 < _list61.size; ++_i62)
               {
-                ResponseIncludes _elem59;
-                _elem59 = ResponseIncludes.findByValue(iprot.readI32());
-                this.responseIncludes.add(_elem59);
+                ResponseIncludes _elem63;
+                _elem63 = ResponseIncludes.findByValue(iprot.readI32());
+                this.responseIncludes.add(_elem63);
               }
               iprot.readListEnd();
             }
@@ -1578,9 +1578,9 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         oprot.writeFieldBegin(WOE_HINT_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.woeHint.size()));
-          for (YahooWoeType _iter60 : this.woeHint)
+          for (YahooWoeType _iter64 : this.woeHint)
           {
-            oprot.writeI32(_iter60.getValue());
+            oprot.writeI32(_iter64.getValue());
           }
           oprot.writeListEnd();
         }
@@ -1592,9 +1592,9 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         oprot.writeFieldBegin(WOE_RESTRICT_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.woeRestrict.size()));
-          for (YahooWoeType _iter61 : this.woeRestrict)
+          for (YahooWoeType _iter65 : this.woeRestrict)
           {
-            oprot.writeI32(_iter61.getValue());
+            oprot.writeI32(_iter65.getValue());
           }
           oprot.writeListEnd();
         }
@@ -1635,9 +1635,9 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         oprot.writeFieldBegin(ALLOWED_SOURCES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.allowedSources.size()));
-          for (String _iter62 : this.allowedSources)
+          for (String _iter66 : this.allowedSources)
           {
-            oprot.writeString(_iter62);
+            oprot.writeString(_iter66);
           }
           oprot.writeListEnd();
         }
@@ -1649,9 +1649,9 @@ public class GeocodeRequest implements TBase<GeocodeRequest, GeocodeRequest._Fie
         oprot.writeFieldBegin(RESPONSE_INCLUDES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.I32, this.responseIncludes.size()));
-          for (ResponseIncludes _iter63 : this.responseIncludes)
+          for (ResponseIncludes _iter67 : this.responseIncludes)
           {
-            oprot.writeI32(_iter63.getValue());
+            oprot.writeI32(_iter67.getValue());
           }
           oprot.writeListEnd();
         }

--- a/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeResponse.java
+++ b/interface/src/main/java/gen-java/com/foursquare/twofishes/GeocodeResponse.java
@@ -433,14 +433,14 @@ public class GeocodeResponse implements TBase<GeocodeResponse, GeocodeResponse._
         case 1: // INTERPRETATIONS
           if (field.type == TType.LIST) {
             {
-              TList _list40 = iprot.readListBegin();
-              this.interpretations = new ArrayList<GeocodeInterpretation>(_list40.size);
-              for (int _i41 = 0; _i41 < _list40.size; ++_i41)
+              TList _list44 = iprot.readListBegin();
+              this.interpretations = new ArrayList<GeocodeInterpretation>(_list44.size);
+              for (int _i45 = 0; _i45 < _list44.size; ++_i45)
               {
-                GeocodeInterpretation _elem42;
-                _elem42 = new GeocodeInterpretation();
-                _elem42.read(iprot);
-                this.interpretations.add(_elem42);
+                GeocodeInterpretation _elem46;
+                _elem46 = new GeocodeInterpretation();
+                _elem46.read(iprot);
+                this.interpretations.add(_elem46);
               }
               iprot.readListEnd();
             }
@@ -451,13 +451,13 @@ public class GeocodeResponse implements TBase<GeocodeResponse, GeocodeResponse._
         case 2: // DEBUG_LINES
           if (field.type == TType.LIST) {
             {
-              TList _list43 = iprot.readListBegin();
-              this.debugLines = new ArrayList<String>(_list43.size);
-              for (int _i44 = 0; _i44 < _list43.size; ++_i44)
+              TList _list47 = iprot.readListBegin();
+              this.debugLines = new ArrayList<String>(_list47.size);
+              for (int _i48 = 0; _i48 < _list47.size; ++_i48)
               {
-                String _elem45;
-                _elem45 = iprot.readString();
-                this.debugLines.add(_elem45);
+                String _elem49;
+                _elem49 = iprot.readString();
+                this.debugLines.add(_elem49);
               }
               iprot.readListEnd();
             }
@@ -491,9 +491,9 @@ public class GeocodeResponse implements TBase<GeocodeResponse, GeocodeResponse._
       oprot.writeFieldBegin(INTERPRETATIONS_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.STRUCT, this.interpretations.size()));
-        for (GeocodeInterpretation _iter46 : this.interpretations)
+        for (GeocodeInterpretation _iter50 : this.interpretations)
         {
-          _iter46.write(oprot);
+          _iter50.write(oprot);
         }
         oprot.writeListEnd();
       }
@@ -504,9 +504,9 @@ public class GeocodeResponse implements TBase<GeocodeResponse, GeocodeResponse._
         oprot.writeFieldBegin(DEBUG_LINES_FIELD_DESC);
         {
           oprot.writeListBegin(new TList(TType.STRING, this.debugLines.size()));
-          for (String _iter47 : this.debugLines)
+          for (String _iter51 : this.debugLines)
           {
-            oprot.writeString(_iter47);
+            oprot.writeString(_iter51);
           }
           oprot.writeListEnd();
         }

--- a/interface/src/main/thrift/geocoder.thrift
+++ b/interface/src/main/thrift/geocoder.thrift
@@ -200,13 +200,14 @@ struct InterpretationDebugInfo {
 }
 
 struct GeocodeInterpretation {
-  1: string what,
-  2: string where,
+  1: string what
+  2: string where
   3: GeocodeFeature feature
-  4: optional list<GeocodeFeature> parents,
-  5: optional ScoringFeatures scoringFeatures_DEPRECATED,
-  6: optional InterpretationScoringFeatures scores,
+  4: optional list<GeocodeFeature> parents
+  5: optional ScoringFeatures scoringFeatures_DEPRECATED
+  6: optional InterpretationScoringFeatures scores
   7: optional InterpretationDebugInfo debugInfo
+  8: optional list<i64> parentLongIds
 }
 
 struct GeocodeResponse {
@@ -324,9 +325,10 @@ struct BulkReverseGeocodeResponse {
 
   3: required list<GeocodeInterpretation> interpretations
   4: list<list<i32>> interpretationIndexes
+  5: optional list<GeocodeFeature> parentFeatures
 
   // only present if debug > 0 in request
-  2: optional list<string> debugLines,
+  2: optional list<string> debugLines
 }
 
 struct BulkSlugLookupRequest {
@@ -337,9 +339,10 @@ struct BulkSlugLookupRequest {
 struct BulkSlugLookupResponse {
   1: required list<GeocodeInterpretation> interpretations
   2: list<list<i32>> interpretationIndexes
+  4: optional list<GeocodeFeature> parentFeatures
 
   // only present if debug > 0 in request
-  3: optional list<string> debugLines,
+  3: optional list<string> debugLines
 }
 
 service Geocoder {

--- a/server/src/main/scala/ReverseGeocoderImpl.scala
+++ b/server/src/main/scala/ReverseGeocoderImpl.scala
@@ -131,8 +131,8 @@ class ReverseGeocoderHelperImpl(
     matches.toSeq
   }
 
-  def doBulkReverseGeocode(otherGeoms: Seq[Geometry]):
-      (Seq[Seq[Int]], Seq[GeocodeInterpretation]) = {
+  def doBulkReverseGeocode(otherGeoms: Seq[Geometry], isolateParents: Boolean = false):
+      (Seq[Seq[Int]], Seq[GeocodeInterpretation], Seq[GeocodeFeature]) = {
     val geomIndexToCellIdMap: Map[Int, Seq[Long]] = (for {
       (g, index) <- otherGeoms.zipWithIndex
     } yield { index -> s2CoverGeometry(g) }).toMap
@@ -203,7 +203,7 @@ class ReverseGeocoderHelperImpl(
     val interpretations = responseProcessor.hydrateParses(sortedParses, parseParams, polygonMap,
       fixAmbiguousNames = false)
 
-    (makeBulkReply[Geometry](otherGeoms, otherGeomToFids, interpretations), interpretations)
+    makeBulkReply[Geometry](otherGeoms, otherGeomToFids, interpretations, isolateParents)
   }
 
   def getAllLevels(): Seq[Int] = {
@@ -224,7 +224,7 @@ class ReverseGeocoderImpl(
     new ReverseGeocoderHelperImpl(store, commonParams, logger)
 
   def doSingleReverseGeocode(geom: Geometry): GeocodeResponse = {
-    val (interpIdxes, interpretations) = reverseGeocoder.doBulkReverseGeocode(List(geom))
+    val (interpIdxes, interpretations, _) = reverseGeocoder.doBulkReverseGeocode(List(geom), isolateParents = false)
     val response = ResponseProcessor.generateResponse(req.debug, logger,
       interpIdxes(0).flatMap(interpIdx => interpretations.lift(interpIdx)))
     if (req.debug > 0) {
@@ -305,12 +305,13 @@ class BulkReverseGeocoderImpl(
 
     val points = req.latlngs.asScala.map(ll => geomFactory.createPoint(new Coordinate(ll.lng, ll.lat)))
 
-    val (interpIdxs, interps) = reverseGeocoder.doBulkReverseGeocode(points)
+    val (interpIdxs, interps, parents) = reverseGeocoder.doBulkReverseGeocode(points, isolateParents = true)
 
     val response = new BulkReverseGeocodeResponse()
       .setDEPRECATED_interpretationMap(Map.empty.asJava)
       .setInterpretationIndexes(interpIdxs.map(_.asJava).asJava)
       .setInterpretations(interps.asJava)
+      .setParentFeatures(parents.asJava)
 
     if (params.debug > 0) {
       response.setDebugLines(logger.getLines.asJava)

--- a/server/src/main/scala/SlugGeocoderImpl.scala
+++ b/server/src/main/scala/SlugGeocoderImpl.scala
@@ -63,15 +63,16 @@ class BulkSlugLookupImpl(
     val interps: Seq[GeocodeInterpretation] = responseProcessor.hydrateParses(parses,
       parseParams, polygonMap, fixAmbiguousNames = true, dedupByMatchedName = false)
 
-    val interpIdxs: Seq[Seq[Int]] = makeBulkReply(
+    val (interpIdxs, retInterps, parents) = makeBulkReply(
       req.slugs.asScala,
       featureMap.mapValues(servingFeature => StoredFeatureId.fromLong(servingFeature.feature.longId).toList),
-      interps)
+      interps, isolateParents = true)
 
     val resp = new BulkSlugLookupResponse()
-    resp.setInterpretations(interps.asJava)
+    resp.setInterpretations(retInterps.asJava)
     // map from input idx to interpretation indexes
     resp.setInterpretationIndexes(interpIdxs.map(_.asJava).asJava)
+    resp.setParentFeatures(parents.asJava)
     if (params.debug > 0) {
       resp.setDebugLines(logger.getLines.asJava)
     }


### PR DESCRIPTION
Prior to sending a bulk response, this commit will extract and de-duplicate all parent features in the interpretations, replace the redundant fields in the intepretations with a list of long ids for each parent feature, and return the de-duplicated parent features in a separate array.

Includes the recompiled codegen files reflecting some new fields in the thrift schema.
