### PR TITLE
Upgrade to sbt-assembly version 0.9.2.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.2")
 
 addSbtPlugin("com.foursquare" % "spindle-codegen-plugin" % "1.5.0")
 


### PR DESCRIPTION
This is the most recent version of sbt-assembly available for sbt
0.12.

Among other improvements, manifests now include organization and
version information (similar to the manifest data produced by the
`package` task).
