### PR TITLE
Preserve original token punctation.

### DIFF
--- a/server/src/test/scala/GeocoderTest.scala
+++ b/server/src/test/scala/GeocoderTest.scala
@@ -436,6 +436,17 @@ class GeocoderSpec extends Specification {
     r.interpretations.size must_== 0
   }
 
+  "original punctuation is preserved" in {
+    val store = buildRegoPark()
+
+    val req = GeocodeRequest.newBuilder.query("carl's jr. near Rego Park, New York").result
+    val r = new GeocodeRequestDispatcher(store).geocode(req)
+    r.interpretations.size must_== 1
+    val interp = r.interpretations(0)
+    interp.what must_== "carl's jr."
+    interp.where must_== "rego park new york"
+  }
+
   "autocomplete" in {
     val store = buildRegoPark()
     addRego(store)

--- a/util/src/main/scala/NameNormalizer.scala
+++ b/util/src/main/scala/NameNormalizer.scala
@@ -9,9 +9,9 @@ object NameNormalizer {
     s.split(" ").filterNot(_.isEmpty).toList
   }
 
-  val spaceRegexp = " +".r
-  val punctRegexp = "\\p{Punct}".r
-  val dotsAndOtherRegexp = "['\u2018\u2019\\.\u2013]".r
+  val whitespaceRegexp = "[ \t]+".r
+  val allPunctuationRegexp = "[\\p{Punct}\\u2018\\u2019\\u2013]+".r
+  val loosePunctuationRegexp = ("\\s+" + allPunctuationRegexp).r
 
   def normalize(s: String): String = {
     var n: String = null
@@ -26,16 +26,15 @@ object NameNormalizer {
       n = s.toLowerCase
     }
 
-    // remove periods and quotes
-    // \u2013 = en-dash
-    n = dotsAndOtherRegexp.replaceAllIn(n, "")
-    // change all other punctuation to spaces
-    n = punctRegexp.replaceAllIn(n, " ")
-    // replace multiple spaces with one
-    n = spaceRegexp.replaceAllIn(n, " ")
-    n = n.replace("\t", " ")
+    // Remove loose punctuation and collapse redundant whitespace.
+    n = loosePunctuationRegexp.replaceAllIn(n, "")
+    n = whitespaceRegexp.replaceAllIn(n, " ")
 
     n
+  }
+
+  def depunctuate(s: String) = {
+    allPunctuationRegexp.replaceAllIn(s, "")
   }
 
   def deaccent(s: String): String = {


### PR DESCRIPTION
Previously, the query parser would aggressively normalize the query
string, and all of the original punctuation would be lost.  There are
cases where we want to preserve word-level punctuation characters,
however.  For example: "carl's jr."

Now, normalize() only removes loose punctuation (i.e. punctuation
characters that aren't part of words).  Then, when building the list
of tokens for name matching, we strip any remaining punctuation.  This
lets us retain the original punctuation in originalTokens.

This adds a small additional cost to each call to parseQueryTokens()
(which is re-invoked for each retry attempt), but because the
expectation is that each call could provide a unique (or modified)
list of new tokens, it should be a fair tradeoff.

This change also fixes a bug where the config.maxTokens would be
applied to the entire original token list and not just the parsable
token list.
