### PR TITLE
Always build "what" from the original tokens.

### DIFF
--- a/server/src/main/scala/ResponseProcessor.scala
+++ b/server/src/main/scala/ResponseProcessor.scala
@@ -381,7 +381,6 @@ class ResponseProcessor(
     val tokens = parseParams.tokens
     val originalTokens = parseParams.originalTokens
     val connectorStart = parseParams.connectorStart
-    val connectorEnd = parseParams.connectorEnd
     val hadConnector = parseParams.hadConnector
 
     // sortedParses.foreach(p => {
@@ -419,7 +418,7 @@ class ResponseProcessor(
       val what = if (hadConnector) {
         originalTokens.take(connectorStart).mkString(" ")
       } else {
-        val whatTokens = tokens.take(tokens.size - parseLength)
+        val whatTokens = originalTokens.take(originalTokens.size - parseLength)
       	(if (whatTokens.lastOption.exists(_ == "in")) {
           whatTokens.dropRight(1)
         } else {


### PR DESCRIPTION
We were already using the original tokens when a connector is present.
We now use the original tokens for connector-less queries, too.
