### PR TITLE
Verify that the hotfix directory actually exists.

### DIFF
--- a/server/src/main/scala/JsonHotfixSource.scala
+++ b/server/src/main/scala/JsonHotfixSource.scala
@@ -3,23 +3,27 @@ package com.foursquare.twofishes
 
 import com.foursquare.common.thrift.json.TReadableJSONProtocol
 import java.io.File
+import com.weiglewilczek.slf4s.Logging
 import org.apache.thrift.TDeserializer
 
-class JsonHotfixSource(originalPath: String) extends HotfixSource {
+class JsonHotfixSource(originalPath: String) extends HotfixSource with Logging {
   val deserializer = new TDeserializer(new TReadableJSONProtocol.Factory())
   var path = ""
   var allEdits: Seq[GeocodeServingFeatureEdit] = Seq()
 
   def init() {
     // reread canonical path in case symlink was modified between refreshes
-    path = new File(originalPath).getCanonicalPath()
+    path = new File(originalPath).getCanonicalPath
     val dir = new File(path)
-    allEdits = dir.listFiles.filter(f => f.getName.endsWith(".json")).flatMap(file => {
-      val edits = new RawGeocodeServingFeatureEdits
-      deserializer.deserialize(edits, scala.io.Source.fromFile(file).getLines.toList.mkString("").getBytes)
-      edits.edits
-    })
-
+    if (dir.exists && dir.isDirectory) {
+      allEdits = dir.listFiles.filter(f => f.getName.endsWith(".json")).flatMap(file => {
+        val edits = new RawGeocodeServingFeatureEdits
+        deserializer.deserialize(edits, scala.io.Source.fromFile(file).getLines().toList.mkString("").getBytes)
+        edits.edits
+      })
+    } else {
+      logger.warn("invalid hotfix directory: %s".format(path))
+    }
   }
 
   def getEdits(): Seq[GeocodeServingFeatureEdit] = allEdits


### PR DESCRIPTION
Otherwise, if an invalid hotfile path was supplied, we'd die with a
NullPointerException deep in the JSON-to-Thrift deserializer.
