### PR TITLE
Move trim to indexing stage from normalizer

### DIFF
--- a/indexer/src/main/scala/importers/geonames/GeonamesParser.scala
+++ b/indexer/src/main/scala/importers/geonames/GeonamesParser.scala
@@ -889,7 +889,7 @@ class GeonamesParser(
 
           // repeat merge for names in name index
           if (merged) {
-            val normalizedName = NameNormalizer.normalize(name)
+            val normalizedName = NameNormalizer.normalize(name).trim
             val nameRecords = store.getNameIndexByIdLangAndName(featureId, lang, normalizedName).toList
             nameRecords match {
               case Nil => logger.error("display names and name index out of sync for id %s, lang %s, name %s".format(idString, lang, name))

--- a/server/src/main/scala/ResponseProcessor.scala
+++ b/server/src/main/scala/ResponseProcessor.scala
@@ -75,7 +75,6 @@ class ResponseProcessor(
           }
         }
 
-
         // negative if a < b
         val isAliasA = isAliasName(a._2)
         val isAliasB = isAliasName(b._2)

--- a/util/src/main/scala/NameNormalizer.scala
+++ b/util/src/main/scala/NameNormalizer.scala
@@ -37,9 +37,8 @@ object NameNormalizer {
     // replace multiple spaces with one
     n = spaceRegexp.replaceAllIn(n, " ")
     n = n.replace("\t", " ")
-
-    // remove any trailing spaces
-    n.trim
+    
+    n
   }
 
   def deaccent(s: String): String = {


### PR DESCRIPTION
Trimming in the normalizer makes `matchNormalizedStringToPrefixOfOriginal` overconsume the matching string, including spaces inside a match when they shouldn't be. This could conceivably cause other issues with autocomplete, where trailing spaces are meaningful.

This approach preserves the index saving behavior but does not introduce the matching bug.

