### PR TITLE
repo.typesafe.com redirects so we need the --location option in curl

### DIFF
--- a/sbt
+++ b/sbt
@@ -33,7 +33,7 @@ fi
 JAR_PATH=`dirname $0`/sbt-launch.jar
 if [ ! -f $JAR_PATH ]; then
   echo "sbt-launch.jar missing, downloading now"
-  curl -o sbt-launch.jar http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.4/sbt-launch.jar
+  curl --location -o sbt-launch.jar http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.4/sbt-launch.jar
 fi
 
 publishTo=$publishTo JAVA_TOOL_OPTIONS="-Xmx6G $JAVA_TOOL_OPTIONS" $JAVA_BINARY  -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M -jar $JAR_PATH "$@"


### PR DESCRIPTION
This follows repo.typesafe.com's redirect to sbt-launch.jar