### PR TITLE
Rework duplicate ordering logic, add feature type preference

### DIFF
--- a/core/src/main/scala/YahooWoeTypes.scala
+++ b/core/src/main/scala/YahooWoeTypes.scala
@@ -15,4 +15,11 @@ object YahooWoeTypes {
   val isAdminWoeTypes = Set(ADMIN3, ADMIN2, ADMIN1, COUNTRY)
   def isAdminWoeType(woeType: YahooWoeType): Boolean =
     isAdminWoeTypes.contains(woeType)
+
+  def compare(woeTypeA: YahooWoeType, woeTypeB: YahooWoeType): Int = {
+    val A = orderMap.get(woeTypeA).getOrElse(Int.MaxValue)
+    val B = orderMap.get(woeTypeB).getOrElse(Int.MaxValue)
+    (A.compare(B))
+  }
+
 }


### PR DESCRIPTION
My attempt to refactor the dupe sorting logic has led me to discover some very dumb choices made in the design of `scala.math.Ordering`

It's also impossible to test any of this because everything is defined inside a method. TODO: factor out orderings into a trait etc, do not merge until then.
