### PR TITLE
data/computed/* should be in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 lib_managed
-data/computed/*
 project*/boot/*
 project*/build/target/*
 project*/plugins/project/*


### PR DESCRIPTION
Based on `docs/twofishes_input.md`:

 `"data/custom -- various transforms on the geonames data that is checked into git."` Given that, we should take data/custom out of gitignore.