### PR TITLE
namespace sbt version, fix java 1.7 search on osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ project*/plugins/project/*
 project*/plugins/lib_managed/*
 project*/plugins/src_managed/*
 project*/plugins/target/*
+project/sbt-launch*.jar
 target
 log/*
 *~

--- a/sbt
+++ b/sbt
@@ -1,23 +1,28 @@
 #!/bin/bash
+set -e
 
-echo $JAVA_HOME
-if [ -z $JAVA_HOME ]
+SBT_VERSION="0.12.4"
+SBT_LAUNCHER="$(dirname $0)/project/sbt-launch-$SBT_VERSION.jar"
+
+if [ ! -e "$SBT_LAUNCHER" ];
 then
-  echo using java from the search path
-  JAVA_BINARY=java
-else
+    URL="http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar"
+    curl -f -L -o  $SBT_LAUNCHER $URL
+fi
+
+# Call with INTERNAL_OPTS followed by SBT_OPTS (or DEFAULT_OPTS). java aways takes the last option when duplicate.
+JAVA_BINARY=java
+if [ -n "$JAVA_HOME" ]; then
   JAVA_BINARY=$JAVA_HOME/bin/java
-  echo running java at $JAVA_BINARY
 fi
 
 $JAVA_BINARY -version 2>&1 | grep -q '1.8'
-
 if [ $? == "0" ]; then
   echo "You are running java 1.8, scala 2.10 requires java 1.7"
   if [ "$(uname)" == "Darwin" ]; then
     echo "On mac, looking for 1.7"
-    JAVA_17=$(ls -d -1 /Library/Java/JavaVirtualMachines/** | grep 1.7)
-    if [ $JAVA_17 ]; then
+    JAVA_17=$(ls -d -1 /Library/Java/JavaVirtualMachines/** | grep 1.7 | tail -n 1)
+    if [ -d $JAVA_17 ]; then
       echo "found at $JAVA_17"
       JAVA_HOME=$JAVA_17/Contents/Home/
       JAVA_BINARY=$JAVA_HOME/bin/java
@@ -30,10 +35,4 @@ if [ $? == "0" ]; then
   fi
 fi
 
-JAR_PATH=`dirname $0`/sbt-launch.jar
-if [ ! -f $JAR_PATH ]; then
-  echo "sbt-launch.jar missing, downloading now"
-  curl --location -o sbt-launch.jar http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.4/sbt-launch.jar
-fi
-
-publishTo=$publishTo JAVA_TOOL_OPTIONS="-Xmx6G $JAVA_TOOL_OPTIONS" $JAVA_BINARY  -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M -jar $JAR_PATH "$@"
+publishTo=$publishTo JAVA_TOOL_OPTIONS="-Xmx6G $JAVA_TOOL_OPTIONS" $JAVA_BINARY  -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M -jar $SBT_LAUNCHER "$@"


### PR DESCRIPTION
- previously failed if more than one 1.7 jvm