### PR TITLE
Fix hotfix adds to parentIds from clobbering old parentIds.

### DIFF
--- a/server/src/main/scala/ConcreteHotfixStorageService.scala
+++ b/server/src/main/scala/ConcreteHotfixStorageService.scala
@@ -43,6 +43,7 @@ class ConcreteHotfixStorageService(
 
   def processLongListEdits(list: Seq[Long], edits: Seq[LongListEdit]): Seq[Long] = {
     var listCopy = list
+
     edits.foreach(edit => {
       edit.editType match {
         case EditType.Add => listCopy = listCopy.filterNot(_ == edit.value) :+ edit.value
@@ -289,9 +290,11 @@ class ConcreteHotfixStorageService(
           // parentIdsEdits
           // edit both feature and servingFeature.scoringFeatures
           if (edit.parentIdsEditsIsSet) {
-            val parentIds = processLongListEdits(
-              featureMutable.parentIds,
-              edit.parentIdsEditsOrThrow)
+            val parentIds =
+              processLongListEdits(
+                servingFeatureMutable.scoringFeatures.parentIds,
+                edit.parentIdsEditsOrThrow
+              )
             featureMutable.parentIds_=(parentIds)
 
             servingFeatureMutable.scoringFeatures_=({


### PR DESCRIPTION
The issue here is that the GeocodeServingFeature for SoHo seems to have Nil parentIds on the GeocodeFeature field.
The parentIds seem to be on the scoringFeatures field, though.
This leads me to suspect it's an issue with how we are building the index, since they should always be the same.